### PR TITLE
FIX: "ERR_CLEARTEXT_NOT_PERMITTED"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"


### PR DESCRIPTION
Previously, when displaying the webView, the following error was displayed: `ERR_CLEARTEXT_NOT_PERMITTED`. This has been fixed by adding `usesCleartextTraffic="true"`.